### PR TITLE
Fix Dockerfile to run MCP server CLI

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,6 @@ COPY . .
 ENV PYTHONUNBUFFERED=1
 EXPOSE 3333
 
-# ---------- launch FastAPI with Uvicorn ----------
-# (module path : FastAPI instance)  →  api_gateway.main:app   ← adjust if different
-CMD ["uvicorn", "api_gateway.main:app", "--host", "0.0.0.0", "--port", "3333"]
+# ---------- launch the MCP server ----------
+# Run the CLI entry point directly instead of using Uvicorn
+CMD ["python", "api_gateway_server.py"]


### PR DESCRIPTION
## Summary
- run the Python MCP server directly instead of Uvicorn

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python test_database.py`

------
https://chatgpt.com/codex/tasks/task_b_68560a02ae5483318a0c6065e7cfe483