### PR TITLE
Fix natural language search formatting

### DIFF
--- a/api_gateway/server.py
+++ b/api_gateway/server.py
@@ -443,9 +443,11 @@ async def natural_language_api_search(query: str, max_results: int = 5) -> str:
             category = endpoint.get('category', 'Unknown')
             
             formatted_results.append(
-                f"{i}. {method} {path}\n"
-                f"   Category: {category}\n"
-                f"   Description: {description}"
+                "".join([
+                    f"{i}. {method} {path}\n",
+                    f"   Category: {category}\n",
+                    f"   Description: {description}"
+                ])
             )
         
         response = "Based on your query, here are the most relevant API endpoints:\n\n"

--- a/tests/test_natural_language_api_search.py
+++ b/tests/test_natural_language_api_search.py
@@ -1,0 +1,37 @@
+import pytest
+from types import SimpleNamespace
+
+import api_gateway.server as server
+
+class DummyDB:
+    def __init__(self, results):
+        self._results = results
+    def search_by_natural_language(self, query, limit):
+        return self._results
+
+@pytest.mark.asyncio
+async def test_natural_language_api_search_formats_results():
+    dummy_results = [
+        {"method": "get", "path": "/tickets", "description": "List tickets", "category": "Service"},
+        {"method": "post", "path": "/tickets", "description": "Create ticket", "category": "Service"},
+    ]
+    original_db = server.api_db
+    server.api_db = DummyDB(dummy_results)
+    try:
+        response = await server.natural_language_api_search("tickets")
+    finally:
+        server.api_db = original_db
+    assert "1. GET /tickets" in response
+    assert "Category: Service" in response
+    assert "Description: List tickets" in response
+    assert "2. POST /tickets" in response
+
+@pytest.mark.asyncio
+async def test_natural_language_api_search_no_results():
+    original_db = server.api_db
+    server.api_db = DummyDB([])
+    try:
+        response = await server.natural_language_api_search("unknown")
+    finally:
+        server.api_db = original_db
+    assert response == "No API endpoints found matching your query."


### PR DESCRIPTION
## Summary
- fix string concatenation in `natural_language_api_search`
- add tests for the helper

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68562c0b60348331896e822aae67997c