### PR TITLE
Fix multiline string assembly

### DIFF
--- a/api_gateway/server.py
+++ b/api_gateway/server.py
@@ -442,11 +442,13 @@ async def natural_language_api_search(query: str, max_results: int = 5) -> str:
             description = endpoint.get('description', 'No description available')
             category = endpoint.get('category', 'Unknown')
             
-            formatted_results.append(
+            formatted_result = (
                 f"{i}. {method} {path}\n"
                 f"   Category: {category}\n"
                 f"   Description: {description}"
             )
+
+            formatted_results.append(formatted_result)
         
         response = "Based on your query, here are the most relevant API endpoints:\n\n"
         response += "\n\n".join(formatted_results)
@@ -642,7 +644,7 @@ async def list_fast_memory(search_term: Optional[str] = None) -> str:
             if len(data_str) > 100:
                 data_str = data_str[:100] + "... (truncated)"
             
-            formatted_queries.append(
+            formatted_query = (
                 f"{i}. {query['description']}\n"
                 f"   ID: {query['id']}\n"
                 f"   Path: {query['method'].upper()} {query['path']}\n"
@@ -650,6 +652,8 @@ async def list_fast_memory(search_term: Optional[str] = None) -> str:
                 f"   Parameters: {params_str}\n"
                 f"   Data: {data_str}"
             )
+
+            formatted_queries.append(formatted_query)
         
         response = "Queries saved in Fast Memory:\n\n"
         response += "\n\n".join(formatted_queries)


### PR DESCRIPTION
## Summary
- properly build single strings before `append`
- preserve multi-line format

## Testing
- `python - <<'EOF'
import asyncio
from api_gateway.server import list_fast_memory
async def main():
    result = await list_fast_memory()
    print(result.splitlines()[:3])
asyncio.run(main())
EOF`

------
https://chatgpt.com/codex/tasks/task_b_68562c1a373083318cff174f782e98cd