### PR TITLE
Add HTTP transport env configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,18 @@ The final HTTP headers sent with every request will look like:
 'Content-Type': 'application/json'
 ```
 
+#### 3. (Optional) Server Settings
+
+Configure how the MCP server starts by setting these environment variables:
+
+```
+FASTMCP_TRANSPORT=stdio    # Use 'streamable-http' for an HTTP server
+FASTMCP_PORT=3333          # Defaults to the PORT variable if set
+```
+
+When deploying to Fly.io, set `FASTMCP_TRANSPORT=streamable-http` so the server
+listens over HTTP.
+
 ## Hosting on Fly.io
 
 1. Install the [Fly CLI](https://fly.io/docs/hands-on/install-flyctl/) and log in:
@@ -330,6 +342,10 @@ python api_gateway_server.py
 # On macOS/Linux
 python3 api_gateway_server.py
 ```
+
+By default the server uses the `stdio` transport. Set `FASTMCP_TRANSPORT=streamable-http`
+and optionally `FASTMCP_PORT` to run an HTTP server (useful when deploying to
+services like Fly.io).
 
 ## Available Tools
 

--- a/api_gateway/server.py
+++ b/api_gateway/server.py
@@ -708,7 +708,25 @@ def main():
     setup_config()
     initialize_database()
     initialize_fast_memory()
-    mcp.run(transport='stdio')
+
+    transport_env = os.environ.get("FASTMCP_TRANSPORT", "stdio").lower()
+    transport = (
+        "streamable-http"
+        if transport_env in {"streamable-http", "http"}
+        else "stdio"
+    )
+
+    port_env = os.environ.get("FASTMCP_PORT") or os.environ.get("PORT")
+    if port_env:
+        try:
+            mcp.settings.port = int(port_env)
+        except ValueError:
+            logger.warning(f"Invalid port value '{port_env}', using default {mcp.settings.port}")
+
+    if transport == "streamable-http":
+        mcp.settings.host = os.environ.get("FASTMCP_HOST", "0.0.0.0")
+
+    mcp.run(transport=transport)
     
 if __name__ == "__main__":
     main()

--- a/fly.toml
+++ b/fly.toml
@@ -5,6 +5,7 @@ dockerfile = "Dockerfile"
 
 [env]
   PORT = "3333"
+  FASTMCP_TRANSPORT = "streamable-http"
 
 [[services]]
   internal_port = 3333


### PR DESCRIPTION
## Summary
- allow `api_gateway.server` to select HTTP or stdio transport
- make port configurable via `FASTMCP_PORT`/`PORT`
- document new env vars
- configure Fly to use HTTP transport

## Testing
- `pip install -r requirements.txt -q`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68563891217483318f8485d969482994