### PR TITLE
Update Fly port settings and default to HTTP server

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,10 +192,14 @@ The final HTTP headers sent with every request will look like:
    ```bash
    fly auth login
    ```
-2. Ensure `fly.toml` sets the correct app name:
+2. Ensure `fly.toml` sets the correct app name and port:
    ```toml
    app = "cwm-api-gateway-mcp"
+
+   [env]
+     FASTMCP_PORT = "3333"
    ```
+   The Docker image exposes the same port and the server runs in HTTP mode by default.
 3. Set your ConnectWise credentials as Fly secrets:
    ```bash
    fly secrets set CONNECTWISE_API_URL=... CONNECTWISE_COMPANY_ID=... \

--- a/api_gateway/server.py
+++ b/api_gateway/server.py
@@ -708,7 +708,7 @@ def main():
     setup_config()
     initialize_database()
     initialize_fast_memory()
-    mcp.run(transport='stdio')
+    mcp.run(transport='streamable-http')
     
 if __name__ == "__main__":
     main()

--- a/fly.toml
+++ b/fly.toml
@@ -5,6 +5,7 @@ dockerfile = "Dockerfile"
 
 [env]
   PORT = "3333"
+  FASTMCP_PORT = "3333"
 
 [[services]]
   internal_port = 3333


### PR DESCRIPTION
## Summary
- set `FASTMCP_PORT` in `fly.toml`
- run FastMCP server in HTTP mode by default
- document Fly deployment configuration and port usage

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_6856389a640883318cc85f16e16c17ad