### PR TITLE
Add dockerignore to exclude build artifacts

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+# Ignore Python cache and build artifacts
+__pycache__/
+*.pyc
+*.egg-info/
+
+# Ignore logs and databases
+*.log
+*.db


### PR DESCRIPTION
## Summary
- avoid sending logs, caches, and DBs in Docker build context by adding `.dockerignore`

## Testing
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68563c1b6a308331a8c2203f39defa47