### PR TITLE
Update default transport logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,11 +192,15 @@ Configure how the MCP server starts by setting these environment variables:
 
 ```
 FASTMCP_TRANSPORT=stdio    # Use 'streamable-http' for an HTTP server
+                           # If PORT is set and FASTMCP_TRANSPORT isn't,
+                           # the server defaults to HTTP
 FASTMCP_PORT=3333          # Defaults to the PORT variable if set
 ```
 
-When deploying to Fly.io, set `FASTMCP_TRANSPORT=streamable-http` so the server
-listens over HTTP.
+When deploying to Fly.io, the platform sets a `PORT` environment variable. If
+`FASTMCP_TRANSPORT` isn't specified the server will automatically listen over
+HTTP. You can still set `FASTMCP_TRANSPORT=streamable-http` explicitly if
+desired.
 
 ## Hosting on Fly.io
 
@@ -343,9 +347,11 @@ python api_gateway_server.py
 python3 api_gateway_server.py
 ```
 
-By default the server uses the `stdio` transport. Set `FASTMCP_TRANSPORT=streamable-http`
-and optionally `FASTMCP_PORT` to run an HTTP server (useful when deploying to
-services like Fly.io).
+By default the server uses the `stdio` transport. If a `PORT` environment
+variable is detected and `FASTMCP_TRANSPORT` isn't specified, the server
+automatically switches to `streamable-http`. You can also explicitly set
+`FASTMCP_TRANSPORT=streamable-http` and optionally `FASTMCP_PORT` to control the
+HTTP port (useful when deploying to services like Fly.io).
 
 ## Available Tools
 

--- a/api_gateway/server.py
+++ b/api_gateway/server.py
@@ -709,14 +709,19 @@ def main():
     initialize_database()
     initialize_fast_memory()
 
-    transport_env = os.environ.get("FASTMCP_TRANSPORT", "stdio").lower()
+    port_env = os.environ.get("FASTMCP_PORT") or os.environ.get("PORT")
+
+    transport_env = os.environ.get("FASTMCP_TRANSPORT")
+    if not transport_env:
+        if os.environ.get("PORT"):
+            transport_env = "streamable-http"
+        else:
+            transport_env = "stdio"
     transport = (
         "streamable-http"
-        if transport_env in {"streamable-http", "http"}
+        if transport_env.lower() in {"streamable-http", "http"}
         else "stdio"
     )
-
-    port_env = os.environ.get("FASTMCP_PORT") or os.environ.get("PORT")
     if port_env:
         try:
             mcp.settings.port = int(port_env)


### PR DESCRIPTION
## Summary
- default to HTTP transport when only `PORT` is set
- describe new behavior in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_68563c1f1ea08331bd295f3b6162f9d0