### PR TITLE
Update PowerShell example to include content type

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,14 +353,17 @@ When running with `FASTMCP_TRANSPORT=streamable-http`, the first HTTP response
 includes an `mcp-session-id` header. Capture this value and send it with all
 subsequent JSON-RPC requests to maintain state. Responses to JSON-RPC messages
 are returned with a `202 Accepted` status while the result is streamed back.
+Include `-ContentType 'application/json'` when calling `Invoke-WebRequest` so
+the server parses the JSON-RPC body correctly.
 
 #### Example Using PowerShell
 
 ```powershell
-$resp = Invoke-WebRequest -Uri http://localhost:3333/ -Method Post -Body '{"jsonrpc":"2.0","id":1,"method":"system.describe"}'
+$resp = Invoke-WebRequest -Uri http://localhost:3333/ -Method Post -ContentType 'application/json' -Body '{"jsonrpc":"2.0","id":1,"method":"system.describe"}'
 $sessionId = $resp.Headers['mcp-session-id']
 
 Invoke-WebRequest -Uri http://localhost:3333/ -Method Post \
+  -ContentType 'application/json' \
   -Body '{"jsonrpc":"2.0","id":2,"method":"search_api_endpoints","params":{"query":"tickets"}}' \
   -Headers @{ 'mcp-session-id' = $sessionId }
 ```


### PR DESCRIPTION
## Summary
- mention content type requirement for JSON-RPC parsing
- add `-ContentType 'application/json'` to PowerShell requests

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685710178ef8833184fd2d6b7f6e0a16